### PR TITLE
Create an index on status_id

### DIFF
--- a/src/main/sqldelight/com/jakewharton/dodo/db/tweet.sq
+++ b/src/main/sqldelight/com/jakewharton/dodo/db/tweet.sq
@@ -23,6 +23,7 @@ CREATE TABLE tweet(
 
 	json TEXT NOT NULL
 );
+CREATE UNIQUE INDEX tweet_status_id ON tweet(status_id);
 
 newest:
 SELECT MAX(status_id) AS status_id

--- a/src/main/sqldelight/migrations/5.sqm
+++ b/src/main/sqldelight/migrations/5.sqm
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX tweet_status_id ON tweet(status_id);


### PR DESCRIPTION
This ensures the COUNT query is fast by using the index rather than having to do a table scan.